### PR TITLE
build: 添加 Docker 配置文件和容器化支持

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+# 安装系统依赖
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libx11-6 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxrandr2 \
+    libxcb1 \
+    libxkbcommon0 \
+    libfontconfig1 \
+    libasound2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# 复制依赖文件并安装
+COPY requirements.txt .
+RUN pip install --no-cache-dir -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements.txt
+
+# 安装Playwright依赖
+RUN playwright install-deps
+
+# 安装Playwright浏览器
+RUN playwright install chromium
+
+# 复制项目文件
+COPY . .
+
+# 启动命令
+CMD ["python", "spider.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  spider:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    environment:
+      - PYTHONUNBUFFERED=1
+    volumes:
+      - ./:/app
+    restart: unless-stopped
+    networks:
+      - spider-network
+
+networks:
+  spider-network:
+    driver: bridge


### PR DESCRIPTION
添加 Dockerfile 和 docker-compose.yml 配置文件以实现容器化部署
Dockerfile 包含 Python 环境配置、系统依赖安装和项目文件复制

运行日志如下：
<img width="1092" height="524" alt="image" src="https://github.com/user-attachments/assets/9a8a7def-ce71-41a1-adbe-e13e9b13c185" />
