### PR TITLE
Set up Cloud Agent dev environment for Xianyu search API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a single Python/FastAPI service: the 闲鱼商品搜索API (Xianyu/Goofish product
+search API) in `spider.py`, which drives a headless Playwright Chromium browser to scrape
+`www.goofish.com` and persists results to a database via Tortoise ORM. `test.py` is an
+optional CLI that reuses the scraper to export results to Excel. Standard setup/run/test
+commands live in `README.md`; only the non-obvious caveats are below.
+
+- Python is available only as `python3` (3.12); there is no `python` symlink. The README
+  shows `python spider.py` / `python test.py` — use `python3` instead.
+- pip installs into the user site (`~/.local`), so console-script shims like `pytest`,
+  `uvicorn`, and `playwright` are NOT on `PATH`. Invoke them as modules:
+  `python3 -m pytest`, `python3 -m playwright ...`, `python3 spider.py`.
+- Live search needs the Playwright Chromium browser (installed by the update script) AND
+  outbound network access to `www.goofish.com`. The scraper is subject to Xianyu anti-bot
+  measures (login popups, `RGV587`/slider captcha), so an occasional run may return few or
+  zero results even though the setup is correct — retry rather than assuming breakage.
+- The database defaults to SQLite at `./xianyu.db` (gitignored) and its schema is
+  auto-created on startup (`generate_schemas=True`); there are no migrations to run. Set
+  `DATABASE_URL` (e.g. in `.env`) to use MySQL instead.
+- Run the server with `python3 spider.py` (listens on `0.0.0.0:8000`); interactive docs are
+  at `http://localhost:8000/docs`. `GET /health` and the unit tests need neither Chromium
+  nor network access; only `POST /search/` does.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the 闲鱼商品搜索API (Xianyu/Goofish product search API) so Cloud Agents can install, test, run, and demo it. No application code was changed — only `AGENTS.md` was added.

## What was set up

- Installed Python deps from `requirements.txt` (Python 3.12, pip → user site).
- Installed the Playwright Chromium browser (`python3 -m playwright install --with-deps chromium`) required for live scraping.
- Configured the Cloud Agent update script:
  - `pip install -r requirements.txt`
  - `python3 -m playwright install --with-deps chromium`

## Verification

| Check | Command | Result |
| --- | --- | --- |
| Unit tests | `python3 -m pytest` | 6 passed |
| Server | `python3 spider.py` | Uvicorn up on `:8000`, `/health` → `{"status":"ok"}` |
| Validation | `POST /search/` empty keyword | 422 as expected |
| Live search (E2E) | `POST /search/ {"keyword":"手机","max_pages":1}` | `status: success`, 59 results, 59 new rows in SQLite |
| Dedup | Second identical search | 60 results, only 31 new (dedup works) |

Demo of the interactive Swagger UI running `/health` and a live `/search/`:

[xianyu_search_api_swagger_demo.mp4](https://cursor.com/agents/bc-fb4a9c09-39bf-4219-bf25-3ddaba0a9036/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fxianyu_search_api_swagger_demo.mp4)

## Notes for future agents (see `AGENTS.md`)

- Use `python3` (no `python` symlink); run console tools as modules (`python3 -m pytest`, `python3 -m playwright ...`).
- Live search needs outbound access to `www.goofish.com` and is subject to anti-bot measures (occasional empty results — retry).
- DB defaults to SQLite `xianyu.db` (gitignored), schema auto-created; no migrations.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb4a9c09-39bf-4219-bf25-3ddaba0a9036?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb4a9c09-39bf-4219-bf25-3ddaba0a9036&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

