### PR TITLE
feat: HTTP 搜索对齐「最新」排序（基于 PR 4）

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## 功能特性
 
 - 🔍 关键词商品搜索（支持分页）
-- ⚡ 异步高性能爬取（Playwright 无头浏览器）
+- ⚡ 异步高性能爬取（HTTP 直连搜索接口，按最新发布排序）
 - 🛡️ 智能数据去重（基于链接特征哈希值）
 - 💾 数据持久化存储（关系数据库）
 - 📊 返回新增记录统计信息
@@ -18,7 +18,7 @@
 | 组件           | 用途                     |
 |----------------|--------------------------|
 | FastAPI        | RESTful API框架          |
-| Playwright     | 浏览器自动化爬取         |
+| httpx          | 异步 HTTP 搜索请求       |
 | Tortoise ORM   | 异步数据库ORM            |
 | SQL            | 数据持久化存储           |
 | Uvicorn        | ASGI服务器               |
@@ -30,7 +30,6 @@
 1. 安装依赖
 ```bash
 pip install -r requirements.txt
-playwright install chromium
 ```
 
 2. 创建 `.env` 文件（请修改为自己的信息）

--- a/api.py
+++ b/api.py
@@ -1,0 +1,116 @@
+import json
+import random
+import string
+import time
+from typing import Optional, Any, Literal, Callable
+
+import httpx
+from pydantic import BaseModel
+from pydantic.main import IncEx
+
+BASE_URL = "https://h5api.m.goofish.com/h5/{}/1.0/"
+APPKEY = "34839810"
+
+client = httpx.AsyncClient()
+
+
+class QueryParams(BaseModel):
+    jsv: str = "2.7.2"
+    appKey: str = APPKEY
+    t: int
+    sign: str
+    v: str = "1.0"
+    type: str = "originaljson"
+    accountSite: str = "xianyu"
+    dataType: str = "json"
+    timeout: int = 20000
+    api: str
+    sessionOption: str = "AutoLoginOnly"
+    spm_cnt: str
+    spm_pre: Optional[str] = None
+
+    @classmethod
+    def create(cls, token: Optional[str], data: dict, api: str, spm_cnt: str, spm_pre: Optional[str] = None):
+        if not token:
+            token = "undefined"
+        t = int(time.time() * 1000)
+        sign = generate_sign(token, APPKEY, data, t)
+        return cls(t=t, api=api, spm_cnt=spm_cnt, spm_pre=spm_pre, sign=sign)
+
+    def model_dump(
+            self,
+            *,
+            mode: Literal['json', 'python'] | str = 'python',
+            include: IncEx | None = None,
+            exclude: IncEx | None = None,
+            context: Any | None = None,
+            by_alias: bool | None = None,
+            exclude_unset: bool = False,
+            exclude_defaults: bool = False,
+            exclude_none: bool = True,
+            round_trip: bool = False,
+            warnings: bool | Literal['none', 'warn', 'error'] = True,
+            fallback: Callable[[Any], Any] | None = None,
+            serialize_as_any: bool = False,
+    ) -> dict[str, Any]:
+        return super().model_dump(mode=mode, include=include, exclude=exclude, context=context,
+                                  by_alias=by_alias, exclude_unset=exclude_unset,
+                                  exclude_defaults=exclude_defaults, exclude_none=True & exclude_none,
+                                  round_trip=round_trip, warnings=warnings, fallback=fallback,
+                                  serialize_as_any=serialize_as_any)
+
+
+async def init():
+    client.headers.update({
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"})
+    # A cookie used to trace user behavior, thus can be randomly generated
+    client.cookies.update({
+        'cna': "".join(random.choices(string.ascii_letters + string.digits, k=25)),
+    })
+    await client.get("https://www.goofish.com/")
+    await init_h5tk()
+    print(client.cookies)
+
+
+async def init_h5tk():
+    """
+    Initialize the _m_h5_tk cookie by making a request to the announcement page.
+    The _m_h5_tk cookie is required for authenticated API requests.
+    """
+    data = {"piUrl": "https://h5.m.goofish.com/wow/moyu/moyu-project/xy-site/pages/announcement"}
+    qp = QueryParams.create(token=None, data=data, api="mtop.gaia.nodejs.gaia.idle.data.gw.v2.index.get",
+                            spm_cnt="a21ybx.home.0.0")
+    response = await client.post(BASE_URL.format("mtop.gaia.nodejs.gaia.idle.data.gw.v2.index.get"),
+                                 params=qp.model_dump(), data={"data": data})
+    print("Get h5tk")
+    print(response.json())
+
+
+def generate_sign(token: str, appkey: str, data: dict, j: int):
+    """
+    Generate the sign parameter for the API request.
+
+    sign = md5(d.token + "&" + j + "&" + h + "&" + c.data)
+    j = (new Date).getTime()
+    h = appkey
+    """
+    import hashlib
+    data = json.dumps(data, separators=(',', ':'))
+    h = appkey
+    sign_str = f"{token}&{j}&{h}&{data}"
+    sign = hashlib.md5(sign_str.encode('utf-8')).hexdigest()
+    return sign
+
+
+async def search(keyword: str, page: int = 1):
+    api = "mtop.taobao.idlemtopsearch.pc.search"
+    data = {"pageNumber": page, "keyword": keyword, "fromFilter": False, "rowsPerPage": 30, "sortValue": "",
+            "sortField": "", "customDistance": "", "gps": "", "propValueStr": {}, "customGps": "",
+            "searchReqFromPage": "pcSearch", "extraFilterValue": "{}", "userPositionJson": "{}"}
+    data_final = json.dumps(data, separators=(',', ':'))
+    url = BASE_URL.format(api)
+    qp = QueryParams.create(token=client.cookies.get("_m_h5_tk").split("_")[0], data=data, api=api,
+                            spm_cnt="a21ybx.search.0.0",
+                            spm_pre="a21ybx.search.searchInput.0")
+    response = await client.post(url, params=qp.model_dump(), data={"data": data_final})
+    return response.json()

--- a/api.py
+++ b/api.py
@@ -11,7 +11,19 @@ from pydantic.main import IncEx
 BASE_URL = "https://h5api.m.goofish.com/h5/{}/1.0/"
 APPKEY = "34839810"
 
-client = httpx.AsyncClient()
+client = httpx.AsyncClient(timeout=20.0)
+SEARCH_API = "mtop.taobao.idlemtopsearch.pc.search"
+
+
+def _dump_data(data: dict) -> str:
+    return json.dumps(data, separators=(",", ":"))
+
+
+def _h5_token() -> str:
+    raw = client.cookies.get("_m_h5_tk")
+    if not raw:
+        raise RuntimeError("缺少 _m_h5_tk，无法签名搜索请求")
+    return raw.split("_")[0]
 
 
 class QueryParams(BaseModel):
@@ -69,7 +81,8 @@ async def init():
     })
     await client.get("https://www.goofish.com/")
     await init_h5tk()
-    print(client.cookies)
+    if not client.cookies.get("_m_h5_tk"):
+        raise RuntimeError("初始化闲鱼 token 失败")
 
 
 async def init_h5tk():
@@ -80,10 +93,12 @@ async def init_h5tk():
     data = {"piUrl": "https://h5.m.goofish.com/wow/moyu/moyu-project/xy-site/pages/announcement"}
     qp = QueryParams.create(token=None, data=data, api="mtop.gaia.nodejs.gaia.idle.data.gw.v2.index.get",
                             spm_cnt="a21ybx.home.0.0")
-    response = await client.post(BASE_URL.format("mtop.gaia.nodejs.gaia.idle.data.gw.v2.index.get"),
-                                 params=qp.model_dump(), data={"data": data})
-    print("Get h5tk")
-    print(response.json())
+    response = await client.post(
+        BASE_URL.format("mtop.gaia.nodejs.gaia.idle.data.gw.v2.index.get"),
+        params=qp.model_dump(),
+        data={"data": _dump_data(data)},
+    )
+    response.raise_for_status()
 
 
 def generate_sign(token: str, appkey: str, data: dict, j: int):
@@ -103,14 +118,35 @@ def generate_sign(token: str, appkey: str, data: dict, j: int):
 
 
 async def search(keyword: str, page: int = 1):
-    api = "mtop.taobao.idlemtopsearch.pc.search"
-    data = {"pageNumber": page, "keyword": keyword, "fromFilter": False, "rowsPerPage": 30, "sortValue": "",
-            "sortField": "", "customDistance": "", "gps": "", "propValueStr": {}, "customGps": "",
-            "searchReqFromPage": "pcSearch", "extraFilterValue": "{}", "userPositionJson": "{}"}
-    data_final = json.dumps(data, separators=(',', ':'))
-    url = BASE_URL.format(api)
-    qp = QueryParams.create(token=client.cookies.get("_m_h5_tk").split("_")[0], data=data, api=api,
-                            spm_cnt="a21ybx.search.0.0",
-                            spm_pre="a21ybx.search.searchInput.0")
+    # 对齐原版 Playwright 点击「新发布 / 最新」后的请求体
+    data = {
+        "pageNumber": page,
+        "keyword": keyword,
+        "fromFilter": True,
+        "rowsPerPage": 30,
+        "sortValue": "desc",
+        "sortField": "create",
+        "customDistance": "",
+        "gps": "",
+        "propValueStr": {"searchFilter": ""},
+        "customGps": "",
+        "searchReqFromPage": "pcSearch",
+        "extraFilterValue": "{}",
+        "userPositionJson": "{}",
+    }
+    data_final = _dump_data(data)
+    url = BASE_URL.format(SEARCH_API)
+    qp = QueryParams.create(
+        token=_h5_token(),
+        data=data,
+        api=SEARCH_API,
+        spm_cnt="a21ybx.search.0.0",
+        spm_pre="a21ybx.search.searchInput.0",
+    )
     response = await client.post(url, params=qp.model_dump(), data={"data": data_final})
-    return response.json()
+    response.raise_for_status()
+    result = response.json()
+    ret = result.get("ret") or []
+    if not any(str(item).startswith("SUCCESS") for item in ret):
+        raise RuntimeError(f"搜索接口调用失败: {ret}")
+    return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ python-dotenv>=0.19.0
 tortoise-orm>=0.19.0
 playwright>=1.32.0
 aiomysql>=0.0.21  # MySQL驱动（如果使用PostgreSQL需替换为asyncpg）
+httpx~=0.28.1
+pydantic~=2.11.7
+pandas~=2.3.2
+tortoise-orm>=0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,3 @@ playwright>=1.32.0
 aiomysql>=0.0.21  # MySQL驱动（如果使用PostgreSQL需替换为asyncpg）
 httpx~=0.28.1
 pydantic~=2.11.7
-pandas~=2.3.2
-tortoise-orm>=0.19.0

--- a/spider.py
+++ b/spider.py
@@ -30,6 +30,7 @@ def get_md5(text: str) -> str:
     """返回给定文本的MD5哈希值"""
     return hashlib.md5(text.encode("utf-8")).hexdigest()
 
+
 def get_link_unique_key(link: str) -> str:
     """
     截取链接中前1个"&"之前的内容作为唯一标识依据。
@@ -42,6 +43,7 @@ def get_link_unique_key(link: str) -> str:
         return '&'.join(parts[:1])
     else:
         return link
+
 
 # 定义数据库模型，增加 link_hash 字段用于唯一性判断
 class XianyuProduct(Model):
@@ -56,9 +58,10 @@ class XianyuProduct(Model):
     link_hash = fields.CharField(max_length=32, unique=True, description="商品链接哈希")
     image_url = fields.TextField(description="商品图片链接", column_type="MEDIUMTEXT")
     publish_time = fields.DatetimeField(null=True, description="发布时间")
-    
+
     class Meta:
         table = "xianyu_products"
+
 
 # 配置数据库
 DATABASE_URL = os.environ.get("DATABASE_URL")
@@ -81,6 +84,7 @@ register_tortoise(
     add_exception_handlers=True,
 )
 
+
 async def safe_get(data, *keys, default="暂无"):
     """安全获取嵌套字典值"""
     for key in keys:
@@ -89,6 +93,7 @@ async def safe_get(data, *keys, default="暂无"):
         except (KeyError, TypeError, IndexError):
             return default
     return data
+
 
 async def save_to_db(data_list):
     """
@@ -114,7 +119,7 @@ async def save_to_db(data_list):
                     "link": link,
                     "image_url": item["商品图片链接"],
                     "publish_time": datetime.strptime(item["发布时间"], "%Y-%m-%d %H:%M")
-                        if item["发布时间"] != "未知时间" else None,
+                    if item["发布时间"] != "未知时间" else None,
                 }
             )
             if created:
@@ -191,7 +196,7 @@ async def scrape_xianyu(keyword: str, max_pages: int = 1):
             await page.goto("https://www.goofish.com")
             await page.fill('input[class*="search-input"]', keyword)
             await page.click('button[type="submit"]')
-            
+
             # 如果存在弹窗广告则关闭
             try:
                 await page.wait_for_selector("div[class*='closeIconBg']", timeout=5000)
@@ -199,29 +204,29 @@ async def scrape_xianyu(keyword: str, max_pages: int = 1):
             except:
                 print("未找到广告弹窗，继续执行")
                 pass
-            
+
             await page.click('text=新发布')
             await page.click('text=最新')
-            
+
             # 注册响应监听
             page.on("response", on_response)
-            
+
             # 分页处理
             current_page = 1
             while current_page <= max_pages:
                 print(f"正在处理第 {current_page} 页")
                 await asyncio.sleep(1)  # 等待数据加载
-                
+
                 # 查找下一页按钮
                 next_btn = await page.query_selector("[class*='search-pagination-arrow-right']:not([disabled])")
                 if not next_btn:
                     break
                 await next_btn.click()
                 current_page += 1
-                
+
         finally:
             await browser.close()
-    
+
     return data_list
 
 
@@ -257,7 +262,7 @@ async def search_items(keyword: str, max_pages: int = 1):
         new_count, new_ids = (0, [])
         if data_list:
             new_count, new_ids = await save_to_db(data_list)
-        
+
         return {
             "status": "success",
             "keyword": keyword,
@@ -269,6 +274,8 @@ async def search_items(keyword: str, max_pages: int = 1):
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=f"爬取失败: {str(e)}")
 
+
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/spider.py
+++ b/spider.py
@@ -1,16 +1,30 @@
+import asyncio
 import hashlib
+import os
+import traceback
+from contextlib import asynccontextmanager
+from datetime import datetime
+
+from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException
 from playwright.async_api import async_playwright
-from datetime import datetime
 from tortoise import Model, fields
 from tortoise.contrib.fastapi import register_tortoise
-from dotenv import load_dotenv
-import asyncio
-import os
+
+from api import init, search
 
 load_dotenv()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await init()
+    yield
+
+
 # 初始化FastAPI应用
-app = FastAPI(title="闲鱼商品搜索API", description="支持并发请求的闲鱼商品搜索接口")
+app = FastAPI(title="闲鱼商品搜索API", description="支持并发请求的闲鱼商品搜索接口", lifespan=lifespan)
+
 
 def get_md5(text: str) -> str:
     """返回给定文本的MD5哈希值"""
@@ -110,56 +124,65 @@ async def save_to_db(data_list):
             print(f"保存数据出错: {str(e)}")
     return new_records, new_ids
 
+
+async def handle_data(data: dict):
+    if str(data).find("NoneOfResult") != -1:
+        return []
+    items = data.get("data", {}).get("resultList", [])
+    res = []
+    for item in items:
+        main_data = await safe_get(item, "data", "item", "main", "exContent", default={})
+        click_params = await safe_get(item, "data", "item", "main", "clickParam", "args", default={})
+
+        # 解析商品信息
+        title = await safe_get(main_data, "title", default="未知标题")
+
+        # 价格处理
+        price_parts = await safe_get(main_data, "price", default=[])
+        price = "价格异常"
+        if isinstance(price_parts, list):
+            price = "".join([str(p.get("text", "")) for p in price_parts if isinstance(p, dict)])
+            price = price.replace("当前价", "").strip()
+            if "万" in price:
+                price = f"¥{float(price.replace('¥', '').replace('万', '')) * 10000:.0f}"
+        # 其他字段解析
+        area = await safe_get(main_data, "area", default="地区未知")
+        seller = await safe_get(main_data, "userNickName", default="匿名卖家")
+        raw_link = await safe_get(item, "data", "item", "main", "targetUrl", default="")
+        image_url = await safe_get(main_data, "picUrl", default="")
+
+        res.append({
+            "商品标题": title,
+            "当前售价": price,
+            "发货地区": area,
+            "卖家昵称": seller,
+            "商品链接": raw_link.replace("fleamarket://", "https://www.goofish.com/"),
+            "商品图片链接": f"https:{image_url}" if image_url and not image_url.startswith(
+                "http") else image_url,
+            "发布时间": datetime.fromtimestamp(
+                int(click_params.get("publishTime", 0)) / 1000
+            ).strftime("%Y-%m-%d %H:%M") if click_params.get("publishTime", "").isdigit() else "未知时间"
+        })
+    return res
+
+
 async def scrape_xianyu(keyword: str, max_pages: int = 1):
     """异步爬取闲鱼商品数据"""
     data_list = []
-    
+
     async with async_playwright() as p:
-        browser = await p.chromium.launch(headless=True)
-        context = await browser.new_context(user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3")
+        browser = await p.chromium.launch(headless=False)
+        context = await browser.new_context(
+            user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3")
         page = await context.new_page()
-        
+
         async def on_response(response):
             """处理API响应，解析数据"""
+            nonlocal data_list
             if "h5api.m.goofish.com/h5/mtop.taobao.idlemtopsearch.pc.search" in response.url:
                 try:
                     result_json = await response.json()
-                    items = result_json.get("data", {}).get("resultList", [])
-                    
-                    for item in items:
-                        main_data = await safe_get(item, "data", "item", "main", "exContent", default={})
-                        click_params = await safe_get(item, "data", "item", "main", "clickParam", "args", default={})
-                        
-                        # 解析商品信息
-                        title = await safe_get(main_data, "title", default="未知标题")
-                        
-                        # 价格处理
-                        price_parts = await safe_get(main_data, "price", default=[])
-                        price = "价格异常"
-                        if isinstance(price_parts, list):
-                            price = "".join([str(p.get("text", "")) for p in price_parts if isinstance(p, dict)])
-                            price = price.replace("当前价", "").strip()
-                            if "万" in price:
-                                price = f"¥{float(price.replace('¥', '').replace('万', '')) * 10000:.0f}"
-                        
-                        # 其他字段解析
-                        area = await safe_get(main_data, "area", default="地区未知")
-                        seller = await safe_get(main_data, "userNickName", default="匿名卖家")
-                        raw_link = await safe_get(item, "data", "item", "main", "targetUrl", default="")
-                        image_url = await safe_get(main_data, "picUrl", default="")
-
-                        data_list.append({
-                            "商品标题": title,
-                            "当前售价": price,
-                            "发货地区": area,
-                            "卖家昵称": seller,
-                            "商品链接": raw_link.replace("fleamarket://", "https://www.goofish.com/"),
-                            "商品图片链接": f"https:{image_url}" if image_url and not image_url.startswith("http") else image_url,
-                            "发布时间": datetime.fromtimestamp(
-                                int(click_params.get("publishTime", 0))/1000
-                            ).strftime("%Y-%m-%d %H:%M") if click_params.get("publishTime", "").isdigit() else "未知时间"
-                        })
-                        
+                    data_list = await handle_data(result_json)
                 except Exception as e:
                     print(f"响应处理异常: {str(e)}")
 
@@ -201,8 +224,24 @@ async def scrape_xianyu(keyword: str, max_pages: int = 1):
     
     return data_list
 
-@app.post("/search/", summary="商品搜索接口", 
-         description="接收搜索关键词和页数，返回爬取结果数量、新增记录数量及新增记录的id列表")
+
+async def scrape_xianyu_http(keyword: str, max_pages: int = 1):
+    async def warped_search(page):
+        async with semaphore:
+            return await handle_data(await search(keyword, page))
+
+    semaphore = asyncio.Semaphore(3)
+    res = []
+    tasks = []
+    for page in range(1, max_pages + 1):
+        tasks.append(warped_search(page))
+    for r in await asyncio.gather(*tasks):
+        res.extend(r)
+    return res
+
+
+@app.post("/search/", summary="商品搜索接口",
+          description="接收搜索关键词和页数，返回爬取结果数量、新增记录数量及新增记录的id列表")
 async def search_items(keyword: str, max_pages: int = 1):
     """
     参数：
@@ -211,8 +250,9 @@ async def search_items(keyword: str, max_pages: int = 1):
     """
     try:
         # 执行爬取
-        data_list = await scrape_xianyu(keyword, max_pages)
-        
+        # data_list = await scrape_xianyu(keyword, max_pages)
+        data_list = await scrape_xianyu_http(keyword, max_pages)
+
         # 保存数据并统计新增记录数，同时返回新增记录的id列表
         new_count, new_ids = (0, [])
         if data_list:
@@ -226,6 +266,7 @@ async def search_items(keyword: str, max_pages: int = 1):
             "new_record_ids": new_ids
         }
     except Exception as e:
+        traceback.print_exc()
         raise HTTPException(status_code=500, detail=f"爬取失败: {str(e)}")
 
 if __name__ == "__main__":

--- a/spider.py
+++ b/spider.py
@@ -7,7 +7,6 @@ from datetime import datetime
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException
-from playwright.async_api import async_playwright
 from tortoise import Model, fields
 from tortoise.contrib.fastapi import register_tortoise
 
@@ -133,7 +132,7 @@ async def save_to_db(data_list):
 async def handle_data(data: dict):
     if str(data).find("NoneOfResult") != -1:
         return []
-    items = data.get("data", {}).get("resultList", [])
+    items = data.get("data", {}).get("resultList") or []
     res = []
     for item in items:
         main_data = await safe_get(item, "data", "item", "main", "exContent", default={})
@@ -171,77 +170,17 @@ async def handle_data(data: dict):
     return res
 
 
-async def scrape_xianyu(keyword: str, max_pages: int = 1):
-    """异步爬取闲鱼商品数据"""
-    data_list = []
-
-    async with async_playwright() as p:
-        browser = await p.chromium.launch(headless=False)
-        context = await browser.new_context(
-            user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3")
-        page = await context.new_page()
-
-        async def on_response(response):
-            """处理API响应，解析数据"""
-            nonlocal data_list
-            if "h5api.m.goofish.com/h5/mtop.taobao.idlemtopsearch.pc.search" in response.url:
-                try:
-                    result_json = await response.json()
-                    data_list = await handle_data(result_json)
-                except Exception as e:
-                    print(f"响应处理异常: {str(e)}")
-
-        try:
-            # 访问首页并操作页面
-            await page.goto("https://www.goofish.com")
-            await page.fill('input[class*="search-input"]', keyword)
-            await page.click('button[type="submit"]')
-
-            # 如果存在弹窗广告则关闭
-            try:
-                await page.wait_for_selector("div[class*='closeIconBg']", timeout=5000)
-                await page.click("div[class*='closeIconBg']")
-            except:
-                print("未找到广告弹窗，继续执行")
-                pass
-
-            await page.click('text=新发布')
-            await page.click('text=最新')
-
-            # 注册响应监听
-            page.on("response", on_response)
-
-            # 分页处理
-            current_page = 1
-            while current_page <= max_pages:
-                print(f"正在处理第 {current_page} 页")
-                await asyncio.sleep(1)  # 等待数据加载
-
-                # 查找下一页按钮
-                next_btn = await page.query_selector("[class*='search-pagination-arrow-right']:not([disabled])")
-                if not next_btn:
-                    break
-                await next_btn.click()
-                current_page += 1
-
-        finally:
-            await browser.close()
-
-    return data_list
-
-
 async def scrape_xianyu_http(keyword: str, max_pages: int = 1):
-    async def warped_search(page):
-        async with semaphore:
-            return await handle_data(await search(keyword, page))
-
     semaphore = asyncio.Semaphore(3)
+
+    async def fetch_page(page: int):
+        async with semaphore:
+            return page, await handle_data(await search(keyword, page))
+
+    gathered = await asyncio.gather(*[fetch_page(page) for page in range(1, max_pages + 1)])
     res = []
-    tasks = []
-    for page in range(1, max_pages + 1):
-        tasks.append(warped_search(page))
-    for r in await asyncio.gather(*tasks):
-        res.extend(r)
+    for _, items in sorted(gathered, key=lambda item: item[0]):
+        res.extend(items)
     return res
 
 
@@ -254,8 +193,6 @@ async def search_items(keyword: str, max_pages: int = 1):
     - max_pages: 最大爬取页数（默认1）
     """
     try:
-        # 执行爬取
-        # data_list = await scrape_xianyu(keyword, max_pages)
         data_list = await scrape_xianyu_http(keyword, max_pages)
 
         # 保存数据并统计新增记录数，同时返回新增记录的id列表


### PR DESCRIPTION
基于 [#4](https://github.com/superboyyy/xianyu_spider/pull/4) 的 HTTP 搜索方案，在本仓库新开分支落地。

## 相对 PR 4 的改动

- 搜索请求改为 Playwright 点「新发布 / 最新」后的参数：`sortField=create`、`sortValue=desc`、`fromFilter=true`、`propValueStr.searchFilter=""`
- `_m_h5_tk` 缺失时明确报错，不再 `None.split`
- 多页结果按页码拼接，避免 `gather` 打乱顺序
- 去掉已不再走的 Playwright 主路径、cookie 调试输出、未使用的 `pandas` 和重复的 `tortoise-orm`
- README 改为 HTTP 搜索说明

`test.py` 仍是 Playwright 脚本，所以 `requirements.txt` 里还留着 `playwright`。

## 实测（关键词「手机」，1 页）

当前分支 HTTP vs Playwright「最新」：

- 30/30 重合
- 顺序完全相同
- 标题、发布时间对齐

